### PR TITLE
Projeto Massaki StarWars Planet Search

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import './App.css';
+import Table from './components/Table';
+import PlanetsProvider from './context/PlanetsProvider';
 
 function App() {
   return (
-    <span>Hello, App!</span>
+    <PlanetsProvider>
+      <span>Hello, App!</span>
+      <Table />
+    </PlanetsProvider>
   );
 }
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -28,7 +28,7 @@ const mockFetch = () => {
     }));
 }
 
-describe('1 - Faça uma requisição para o endpoint `/planets` da API de Star Wars e preencha uma tabela com os dados retornados, com exceção dos da coluna `residents`', () => {
+describe.only('1 - Faça uma requisição para o endpoint `/planets` da API de Star Wars e preencha uma tabela com os dados retornados, com exceção dos da coluna `residents`', () => {
   beforeAll(mockFetch);
   beforeEach(cleanup);
 

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,0 +1,46 @@
+import React, { useContext } from 'react';
+import PlanetsContext from '../context/PlanetsContext';
+
+export default function Table() {
+  const { data } = useContext(PlanetsContext);
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Rotation Period</th>
+          <th>Orbital Period</th>
+          <th>Diameter</th>
+          <th>Climate</th>
+          <th>Gravity</th>
+          <th>Terrain</th>
+          <th>Surface Water</th>
+          <th>Population</th>
+          <th>Films</th>
+          <th>Created</th>
+          <th>Edited</th>
+          <th>URL</th>
+        </tr>
+      </thead>
+      <tbody>
+        { data.map((planet) => (
+          <tr key={ planet.name }>
+            <td>{planet.name}</td>
+            <td>{planet.rotation_period}</td>
+            <td>{planet.orbital_period}</td>
+            <td>{planet.diameter}</td>
+            <td>{planet.climate}</td>
+            <td>{planet.gravity}</td>
+            <td>{planet.terrain}</td>
+            <td>{planet.surface_water}</td>
+            <td>{planet.population}</td>
+            <td>{planet.films}</td>
+            <td>{planet.created}</td>
+            <td>{planet.edited}</td>
+            <td>{planet.url}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/context/PlanetsContext.js
+++ b/src/context/PlanetsContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const PlanetsContext = createContext();
+
+export default PlanetsContext;

--- a/src/context/PlanetsProvider.js
+++ b/src/context/PlanetsProvider.js
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import PlanetsContext from './PlanetsContext';
+
+function PlanetsProvider({ children }) {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    fetch('https://swapi-trybe.herokuapp.com/api/planets/').then((response) => response.json()).then((result) => setData(result.results));
+  }, []);
+
+  const context = { data, setData };
+
+  return <PlanetsContext.Provider value={ context }>{children}</PlanetsContext.Provider>;
+}
+
+export default PlanetsProvider;
+
+PlanetsProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};


### PR DESCRIPTION
## Requisitos Obrigatórios:
- [x] 1 - Faça uma requisição para o endpoint /planets da API de Star Wars e preencha uma tabela com os dados retornados, com exceção dos da coluna residents
- [ ] 2 - Filtre a tabela através de um texto, inserido num campo de texto, exibindo somente os planetas cujos nomes incluam o texto digitado
- [ ] 3 - Crie um filtro para valores numéricos
- [ ] 4 - Não utilize filtros repetidos
- [ ] 5 - Apague o filtro de valores numéricos e desfaça as filtragens dos dados da tabela ao clicar no ícone de X de um dos filtros
## Requisitos Bônus:
- [ ] 6 - Ordene as colunas de forma ascendente ou descendente